### PR TITLE
Provide alternate search path for assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,22 @@ Extracted from the grunt plugin [grunt-useref](https://github.com/pajtai/grunt-u
 
     useref = require('useref')
     var result = useref(inputHtml)
-    // result = [ replacedHtml, { type: { id: [ replacedFiles] }} ]
+    // result = [ replacedHtml, { type: { path: { 'assets': [ replacedFiles] }}} ]
 
 
-The build block syntax is `build:type id`. Valid types are `js` and `css`
+Blocks are expressed as:
+
+```html
+<!-- build:<type>(alternate search path) <path> -->
+... HTML Markup, list of script / link tags.
+<!-- endbuild -->
+```
+
+- **type**: either `js` or `css`
+- **alternate search path**: (optional) By default the input files are relative to the treated file. Alternate search path allows one to change that
+- **path**: the file path of the optimized file, the target output
+
+An example of this in completed form can be seen below:
 
     <html>
     <head>
@@ -40,10 +52,14 @@ The module would be used with the above sample HTML as follows:
     //   resultHtml,
     //   {
     //     css: {
-    //       'css/combined.css': [ 'css/one.css', 'css/two.css' ]
+    //       'css/combined.css': {
+    //         'assets': [ 'css/one.css', 'css/two.css' ]
+    //       }
     //     },
     //     js: {
-    //       'scripts/combined.js': [ 'css/one.js', 'css/two.js' ]
+    //       'scripts/combined.js': {
+    //         'assets': [ 'css/one.js', 'css/two.js' ]
+    //       }
     //     }
     //   }
     // ]

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,15 @@
+/* jshint node: true */
+/* global describe, it */
+'use strict';
 var expect = require('chai').expect;
 var fs = require('fs');
 var path = require('path');
 var useRef = require('../src/index');
 
-function djoin(p) { 
+function djoin(p) {
   return path.normalize(path.join(__dirname, p));
 }
-function fread(f) { 
+function fread(f) {
   return fs.readFileSync(f, { encoding: 'utf-8'});
 }
 
@@ -16,20 +19,20 @@ describe('html-ref-replace', function() {
   it('should replace reference in css block and return replaced files', function() {
     var result = useRef(fread(djoin('testfiles/01.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/01-expected.html')));
-    expect(result[1]).to.eql({ css: { '/css/combined.css': [ '/css/one.css', '/css/two.css' ] }});
+    expect(result[1]).to.eql({ css: { '/css/combined.css': { 'assets': [ '/css/one.css', '/css/two.css' ] }}});
   });
 
 
   it('should replace reference in js block and return replaced files', function() {
     var result = useRef(fread(djoin('testfiles/02.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/02-expected.html')));
-    expect(result[1]).to.eql({ js: { 'scripts/combined.concat.min.js': [ 'scripts/this.js', 'scripts/that.js' ] }});
+    expect(result[1]).to.eql({ js: { 'scripts/combined.concat.min.js': { 'assets': [ 'scripts/this.js', 'scripts/that.js' ] }}});
   });
 
   it('should handle comments and whitespace in blocks', function() {
     var result = useRef(fread(djoin('testfiles/03.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/03-expected.html')));
-    expect(result[1]).to.eql({ js: { 'scripts/combined.concat.min.js': [ 'scripts/this.js', 'scripts/that.js' ] }});    
+    expect(result[1]).to.eql({ js: { 'scripts/combined.concat.min.js': { 'assets': [ 'scripts/this.js', 'scripts/that.js' ] }}});
   });
 
   it('should handle multiple blocks', function() {
@@ -37,13 +40,23 @@ describe('html-ref-replace', function() {
     expect(result[0]).to.equal(fread(djoin('testfiles/04-expected.html')));
     expect(result[1]).to.eql({
       js: {
-        'scripts/combined.concat.min.js': [ 'scripts/this.js', 'scripts/that.js' ],
-        'scripts/combined2.concat.min.js': [ 'scripts/anotherone.js', 'scripts/yetonemore.js' ]
+        'scripts/combined.concat.min.js': { 'assets': [ 'scripts/this.js', 'scripts/that.js' ] },
+        'scripts/combined2.concat.min.js': { 'assets': [ 'scripts/anotherone.js', 'scripts/yetonemore.js' ] }
       },
       css: {
-        '/css/combined.css': [ '/css/one.css', '/css/two.css' ],
-        '/css/combined2.css': [ '/css/three.css', '/css/four.css' ]
+        '/css/combined.css': { 'assets': [ '/css/one.css', '/css/two.css' ] },
+        '/css/combined2.css': { 'assets': [ '/css/three.css', '/css/four.css' ] }
       }
-    }); 
-  })
+    });
+  });
+
+  it('should return the alternate search path in css block', function() {
+    var result = useRef(fread(djoin('testfiles/05.html')));
+    expect(result[1].css['/css/combined.css'].searchPaths).to.equal('.tmp');
+  });
+
+  it('should return the alternate search path in js block', function() {
+    var result = useRef(fread(djoin('testfiles/06.html')));
+    expect(result[1].js['scripts/combined.concat.min.js'].searchPaths).to.equal('{.tmp,app}');
+  });
 });

--- a/test/testfiles/05.html
+++ b/test/testfiles/05.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <!-- build:css(.tmp) /css/combined.css -->
+  <link href="/css/one.css" rel="stylesheet">
+  <link href="/css/two.css" rel="stylesheet">
+  <!-- endbuild -->
+</head>
+</html>

--- a/test/testfiles/06.html
+++ b/test/testfiles/06.html
@@ -1,0 +1,9 @@
+<html>
+<head></head>
+<body>
+<!-- build:js({.tmp,app}) scripts/combined.concat.min.js -->
+<script type="text/javascript" src="scripts/this.js"></script>
+<script type="text/javascript" src="scripts/that.js"></script>
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
By default the input files are relative to the treated file. Alternate
search path allows one to change that. This would allow for functionality
similar to https://github.com/yeoman/grunt-usemin.
