### PR TITLE
Fix alternate search paths.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,6 @@ function getBlocks(body) {
     if (build) {
       block = true;
       sections[[build[1], build[3].trim()].join(':')] = last = [];
-
-      if (build[2]) {
-        // Alternate search path
-        sections.searchPaths = build[2];
-      }
     }
 
     // switch back block flag when endbuild
@@ -109,14 +104,12 @@ function updateReferences(blocks, content) {
 
   // handle blocks
   Object.keys(blocks).forEach(function (key) {
-    if (key !== 'searchPaths') {
-      var block = blocks[key].join(linefeed),
-          parts = key.split(':'),
-          type = parts[0],
-          target = parts[1];
+    var block = blocks[key].join(linefeed),
+      parts = key.split(':'),
+      type = parts[0],
+      target = parts[1];
 
-      content = helpers.useref(content, block, target, type);
-    }
+    content = helpers.useref(content, block, target, type);
   });
 
   return content;
@@ -127,36 +120,36 @@ function compactContent(blocks) {
   var result = {};
 
   Object.keys(blocks).forEach(function (dest) {
-    if (dest !== 'searchPaths') {
-      // Lines are the included scripts w/o the use blocks
-      var lines = blocks[dest].slice(1, -1),
-          parts = dest.split(':'),
-          type = parts[0],
-          // output is the useref block file
-          output = parts[1];
+    // Lines are the included scripts w/o the use blocks
+    var lines = blocks[dest].slice(1, -1),
+      parts = dest.split(':'),
+      type = parts[0],
+      // output is the useref block file
+      output = parts[1],
+      build = String.prototype.match.apply( blocks[dest][0], [regbuild] );
 
-      // parse out the list of assets to handle, and update the grunt config accordingly
-      var assets = lines.map(function (tag) {
+    // parse out the list of assets to handle, and update the grunt config accordingly
+    var assets = lines.map(function (tag) {
 
-        // The asset is the string of the referenced source file
-        var asset = (tag.match(/(href|src)=["']([^'"]+)["']/) || [])[2];
+      // The asset is the string of the referenced source file
+      var asset = (tag.match(/(href|src)=["']([^'"]+)["']/) || [])[2];
 
-        // Allow white space and comment in build blocks by checking if this line has an asset or not
-        if (asset) {
-          return asset;
-        }
-
-      }).reduce(function (a, b) {
-            b = (b ? b.split(',') : '');
-            return b ? a.concat(b) : a;
-          }, []);
-
-
-      result[type] = result[type] || {};
-      result[type][output] = { 'assets': assets };
-      if (blocks.searchPaths) {
-        result[type][output].searchPaths = blocks.searchPaths;
+      // Allow white space and comment in build blocks by checking if this line has an asset or not
+      if (asset) {
+        return asset;
       }
+
+    }).reduce(function (a, b) {
+      b = (b ? b.split(',') : '');
+      return b ? a.concat(b) : a;
+    }, []);
+
+
+    result[type] = result[type] || {};
+    result[type][output] = { 'assets': assets };
+    if (build[2]) {
+      // Alternate search path
+      result[type][output].searchPaths = build[2];
     }
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -59,4 +59,9 @@ describe('html-ref-replace', function() {
     var result = useRef(fread(djoin('testfiles/06.html')));
     expect(result[1].js['scripts/combined.concat.min.js'].searchPaths).to.equal('{.tmp,app}');
   });
+
+  it('should return the alternate search path in multiple blocks', function() {
+    var result = useRef(fread(djoin('testfiles/07.html')));
+    expect(result[1].js['scripts/combined2.min.js'].searchPaths).to.equal('.tmp');
+  });
 });

--- a/test/testfiles/07.html
+++ b/test/testfiles/07.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <!-- build:css /css/combined.css -->
+    <link href="/css/one.css" rel="stylesheet">
+    <link href="/css/two.css" rel="stylesheet">
+    <!-- endbuild -->
+</head>
+<body>
+
+<!-- build:js scripts/combined.min.js -->
+<script type="text/javascript" src="scripts/this.js"></script>
+<script type="text/javascript" src="scripts/that.js"></script>
+<!-- endbuild -->
+
+<!-- build:js(.tmp) scripts/combined2.min.js -->
+<script type="text/javascript" src="scripts/anotherone.js"></script>
+<script type="text/javascript" src="scripts/yetonemore.js"></script>
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
Alternate search paths are currently not working correctly. With multiple blocks, the same search path is used for both. For example, in the following `index.html`

```
<!-- build:js scripts/vendor.js -->
  <script src="vendor/jquery/dist/jquery.js"></script>
  <script src="vendor/bootstrap-sass/dist/js/bootstrap.js"></script>
<!-- endbuild -->

<!-- build:js(.tmp) scripts/app.js -->
  <script src="index.js"></script>
<!-- endbuild -->
```

The search path should be `.tmp` only for the second block, but it also affects the first block. You will get an error on `gulp-useref/index.js:54:44`, because `filepath` on line 52 is `/path/to/app/.tmp`, but it's actually looking for `vendor/jquery/dist/jquery.js`.

This patch fixes the problem, adds a passing test and cleans up the code branching that was added before that was not needed.
