### PR TITLE
Useref should remove empty blocks.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,13 +44,13 @@ module.exports = function (content) {
 //
 function getBlocks(body) {
   var lines = body.replace(/\r\n/g, '\n').split(/\n/),
-      block = false,
-      sections = {},
-      last;
+    block = false,
+    sections = {},
+    last;
 
   lines.forEach(function (l) {
     var build = l.match(regbuild),
-        endbuild = regend.test(l);
+      endbuild = regend.test(l);
 
     if (build) {
       block = true;
@@ -79,21 +79,22 @@ function getBlocks(body) {
 var helpers = {
   // useref and useref:* are used with the blocks parsed from directives
   useref: function (content, block, target, type) {
+    var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n',
+        lines = block.split(linefeed),
+        refs = lines.slice(1, -1),
+        ref = '',
+        indent = (lines[0].match(/^\s*/) || [])[0];
+
     target = target || 'replace';
 
-    return helpers['useref_' + type](content, block, target);
-  },
-
-  useref_css: function (content, block, target) {
-    var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n';
-    var indent = (block.split(linefeed)[0].match(/^\s*/) || [])[0];
-    return content.replace(block, indent + '<link rel="stylesheet" href="' + target + '"\/>');
-  },
-
-  useref_js: function (content, block, target) {
-    var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n';
-    var indent = (block.split(linefeed)[0].match(/^\s*/) || [])[0];
-    return content.replace(block, indent + '<script src="' + target + '"></script>');
+    if (refs.length) {
+      if (type === 'css') {
+        ref = '<link rel="stylesheet" href="' + target + '"\/>';
+      } else if (type === 'js') {
+        ref = '<script src="' + target + '"></script>';
+      }
+    }
+    return content.replace(block, indent + ref);
   }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,11 @@ describe('html-ref-replace', function() {
     });
   });
 
+  it('should remove empty blocks', function() {
+    var result = useRef(fread(djoin('testfiles/08.html')));
+    expect(result[0]).to.equal(fread(djoin('testfiles/08-expected.html')));
+  });
+
   it('should return the alternate search path in css block', function() {
     var result = useRef(fread(djoin('testfiles/05.html')));
     expect(result[1].css['/css/combined.css'].searchPaths).to.equal('.tmp');

--- a/test/testfiles/08-expected.html
+++ b/test/testfiles/08-expected.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+  
+</head>
+</html>

--- a/test/testfiles/08.html
+++ b/test/testfiles/08.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+  <!-- build:css /css/vendor.css -->
+  <!-- endbuild -->
+</head>
+</html>


### PR DESCRIPTION
Currently, useref replaces build blocks with a new tag even if the blocks are empty. This patch simply removes the build block altogether if it is empty.
