### PR TITLE
Support replacing references for empty blocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,18 +90,16 @@ var helpers = {
 
     target = target || 'replace';
 
-    if (refs.length) {
-      if (type === 'css') {
-        ref = '<link rel="stylesheet" href="' + target + '"\/>';
-      } else if (type === 'js') {
-        ref = '<script src="' + target + '"></script>';
-      }
-      else if (type == 'remove') {
-        ref = '';
-      }
-      else if (type == 'jsasync') {
-        ref = '<script src="' + target + '" async ></script>'
-      }
+    if (type === 'css') {
+      ref = '<link rel="stylesheet" href="' + target + '"\/>';
+    } else if (type === 'js') {
+      ref = '<script src="' + target + '"></script>';
+    }
+    else if (type == 'remove') {
+      ref = '';
+    }
+    else if (type == 'jsasync') {
+      ref = '<script src="' + target + '" async ></script>'
     }
     return content.replace(block, indent + ref);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -62,9 +62,10 @@ describe('html-ref-replace', function() {
     });
   });
 
-  it('should remove empty blocks', function() {
+  it('should replace reference in empty blocks', function() {
     var result = useRef(fread(djoin('testfiles/08.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/08-expected.html')));
+    expect(result[1]).to.eql({ css: { '/css/vendor.css': { 'assets': [ ] }}});
   });
 
   it('should return the alternate search path in css block', function() {

--- a/test/testfiles/08-expected.html
+++ b/test/testfiles/08-expected.html
@@ -1,5 +1,5 @@
 <html>
 <head>
-  
+  <link rel="stylesheet" href="/css/vendor.css"/>
 </head>
 </html>


### PR DESCRIPTION
Usemin supports a similar use case.

An example of where we use this... Using something like https://github.com/miickel/gulp-angular-templatecache to generate a `templates.js` from a bunch of HTML partials and having useref / usemin link it into the `index.html`.
