### PR TITLE
[bug] CSS link tag trailing slash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ var helpers = {
 
     if (refs.length) {
       if (type === 'css') {
-        ref = '<link rel="stylesheet" href="' + target + '"\/>';
+        ref = '<link rel="stylesheet" href="' + target + '">';
       } else if (type === 'js') {
           if(attbs) {
               ref = '<script src="' + target + '" ' + attbs + ' ></script>'


### PR DESCRIPTION
Let's say I have:

```
<!-- build:css build/css/app.min.css -->
<link rel="stylesheet" href="/assets/third-party/bootstrap/dist/css/bootstrap.min.css">
<!-- endbuild -->
```

which outputs:

```
<link rel="stylesheet" href="build/css/app.min.css"/>
```

This is invalid HTML because the link tag should not contain a trailing slash. I'm running into this bug trying to run gulp-prefix on the link tags after useref completes, but gulp-prefix bails on the link tags created by gulp-useref on account of this trailing slash.

My original gulp-useref [issue](https://github.com/jonkemp/gulp-useref/issues/35#issuecomment-47261753) was redirected here, and this PR provides a simple fix to make the outputted link tag conform to the HTML5 spec.
