### PR TITLE
Support extra html attributes on css replacement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,11 @@ var helpers = {
 
     if (refs.length) {
       if (type === 'css') {
-        ref = '<link rel="stylesheet" href="' + target + '">';
+          if(attbs) {
+              ref = '<link rel="stylesheet" href="' + target + '" ' + attbs + ' >';
+          } else {
+              ref = '<link rel="stylesheet" href="' + target + '">';
+          }
       } else if (type === 'js') {
           if(attbs) {
               ref = '<script src="' + target + '" ' + attbs + ' ></script>'


### PR DESCRIPTION
Allow extra html attributes on css include replacement, the same way as it currently works for javascript includes.

Currently this block:

``` html
<!-- build:css(build/static/) /static/css/print.css media="print" -->
      <link rel="stylesheet" href="/css/print.css" type="text/css" media="print" />
<!-- endbuild -->
```

will produce: 

```
    <link rel="stylesheet" href="/static/css/print-c10c1037.css">
```

After the patch the output will be:

```
    <link rel="stylesheet" href="/static/css/print-c10c1037.css" media="print">
```
