### PR TITLE
Google font urls broke if there is a split

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,6 @@ function compactContent(blocks) {
       }
 
     }).reduce(function (a, b) {
-      b = (b ? b.split(',') : '');
       return b ? a.concat(b) : a;
     }, []);
 


### PR DESCRIPTION
See issue #25 
