### PR TITLE
Add custom block support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,40 @@ Results in:
 <script src="scripts/combined.js"></script>
 <![endif]-->
 ```
+
+### Custom blocks
+
+Sometimes you need a bit more. If you would like to do custom processing, this is possible with a custom block, as demonstrated below.
+
+```
+<!-- build:import components -->
+<link rel="import" href="/bower_components/some/path"></link>
+<!-- endbuild -->
+```
+
+With
+
+```
+useref = require('node-useref')
+var result = useref(inputHtml, {
+  // each property corresponds to any blocks with the same name, e.g. "build:import"
+  import: function (content, target, options) {
+    // do something with `content` and return the desired HTML to replace the block content
+    return content.replace('bower_components', target);
+  }
+});
+```
+
+Becomes
+
+```
+<link rel="import" href="/components/some/path"></link>
+```
+
+The handler function gets the following arguments:
+
+- *content* (String): The content of the custom use block
+- *target* (String): The "path" value of the use block definition
+- *options* (String): The extra attributes from the use block definition, the developer can parse as JSON or do whatever they want with it
+
+Include a handler for each custom block type.

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ var helpers = {
     } else if (type === 'remove') {
         ref = '';
     } else {
-      ref = handler(blockContent, target);
+      ref = handler(blockContent, target, attbs);
     }
 
     ref = indent + ref;

--- a/test/test.js
+++ b/test/test.js
@@ -143,7 +143,7 @@ describe('html-ref-replace', function() {
 
   it('should allow custom blocks', function() {
     var result = useRef(fread(djoin('testfiles/22.html')), {
-      test: function (content, target) {
+      test: function (content, target, options) {
         return content.replace('bower_components', target);
       }
     });

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,6 @@ function fread(f) {
   return fs.readFileSync(f, { encoding: 'utf-8'});
 }
 
-
 describe('html-ref-replace', function() {
 
   it('should replace reference in css block and return replaced files', function() {
@@ -21,7 +20,6 @@ describe('html-ref-replace', function() {
     expect(result[0]).to.equal(fread(djoin('testfiles/01-expected.html')));
     expect(result[1]).to.eql({ css: { '/css/combined.css': { 'assets': [ '/css/one.css', '/css/two.css' ] }}});
   });
-
 
   it('should replace reference in js block and return replaced files', function() {
     var result = useRef(fread(djoin('testfiles/02.html')));
@@ -116,7 +114,6 @@ describe('html-ref-replace', function() {
     expect(result[0]).to.equal(fread(djoin('testfiles/16-win-expected.html')));
   });
 
-
   it('should replace css blocks with attributes containing `:` and parenthesis', function() {
     var result = useRef(fread(djoin('testfiles/17.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/17-expected.html')));
@@ -142,6 +139,16 @@ describe('html-ref-replace', function() {
     var result = useRef(fread(djoin('testfiles/21.html')));
     expect(result[0]).to.equal(fread(djoin('testfiles/21-expected.html')));
     expect(result[1]).to.eql({ js: { 'scripts/combined.concat.min.js': { 'assets': [ 'http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' ] }}});
+  });
+
+  it('should allow custom blocks', function() {
+    var result = useRef(fread(djoin('testfiles/22.html')), {
+      test: function (content, target) {
+        return content.replace('bower_components', target);
+      }
+    });
+    expect(result[0]).to.equal(fread(djoin('testfiles/22-expected.html')));
+
   });
 
 });

--- a/test/testfiles/22-expected.html
+++ b/test/testfiles/22-expected.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+<link rel="import" href="/components/some/path"></link>
+</body>
+</html>

--- a/test/testfiles/22.html
+++ b/test/testfiles/22.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+<!-- build:test components -->
+<link rel="import" href="/bower_components/some/path"></link>
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
As the name suggests, adds support for custom "use" blocks. 

```
<!-- build:import components -->
<link rel="import" href="/bower_components/some/path"></link>
<!-- endbuild -->
```

With

```
useref = require('node-useref')
var result = useref(inputHtml, {
  // each property corresponds to any blocks with the same name, e.g. "build:import"
  import: function (content, target, options) {
    // do something with `content` and return the desired HTML to replace the block content
    return content.replace('bower_components', target);
  }
});
```

Becomes

```
<link rel="import" href="/components/some/path"></link>
```

The handler function gets the following arguments:

- *content* (String): The content of the custom use block
- *target* (String): The "path" value of the use block definition
- *options* (String): The extra attributes from the use block definition, the developer can parse as JSON or do whatever they want with it

Reference: jonkemp/gulp-useref#85