### PR TITLE
Expose alternateSearchPaths to custom blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,5 +151,6 @@ The handler function gets the following arguments:
 - *content* (String): The content of the custom use block
 - *target* (String): The "path" value of the use block definition
 - *options* (String): The extra attributes from the use block definition, the developer can parse as JSON or do whatever they want with it
+- *alternateSearchPath* (String): The alternate search path that can be used to maintain a coherent interface with standard handlers
 
 Include a handler for each custom block type.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ With
 useref = require('node-useref')
 var result = useref(inputHtml, {
   // each property corresponds to any blocks with the same name, e.g. "build:import"
-  import: function (content, target, options) {
+  import: function (content, target, options, alternateSearchPath) {
     // do something with `content` and return the desired HTML to replace the block content
     return content.replace('bower_components', target);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ function getBlocks(body) {
 // -------
 var helpers = {
   // useref and useref:* are used with the blocks parsed from directives
-  useref: function (content, block, target, type, attbs, handler) {
+  useref: function (content, block, target, type, attbs, alternateSearchPaths, handler) {
     var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n',
         lines = block.split(linefeed),
         ref = '',
@@ -138,7 +138,7 @@ var helpers = {
     } else if (type === 'remove') {
         ref = '';
     } else if (handler) {
-      ref = handler(blockContent, target, attbs);
+      ref = handler(blockContent, target, attbs, alternateSearchPaths);
     }
     else {
       ref = null;
@@ -166,13 +166,14 @@ function updateReferences(blocks, content, options) {
   // handle blocks
   Object.keys(blocks).forEach(function (key) {
     var block = blocks[key].join(linefeed),
-      parts = key.split(sectionsJoinChar),
-      type = parts[0],
-      target = parts[1],
-      attbs =  parts[2],
+      parts = block.match(regbuild),
+      type = parts[1],
+      alternateSearchPaths = parts[2],
+      target = parts[3],
+      attbs =  parts[4] && parts[4].trim(),
       handler = options && options[type];
 
-    content = helpers.useref(content, block, target, type, attbs, handler);
+    content = helpers.useref(content, block, target, type, attbs, alternateSearchPaths, handler);
   });
 
   return content;

--- a/test/test.js
+++ b/test/test.js
@@ -155,4 +155,11 @@ describe('html-ref-replace', function() {
     expect(result[0]).to.equal(fread(djoin('testfiles/23.html')));
   });
 
+  it('should pass alternateSearchPath to the custom block handler', function () {
+    useRef(fread(djoin('testfiles/24.html')), {
+      test: function (content, target, options, alternateSearchPath) {
+        expect(alternateSearchPath).to.equal('{.tmp,app}');
+      }
+    });
+  });
 });

--- a/test/testfiles/24.html
+++ b/test/testfiles/24.html
@@ -1,0 +1,7 @@
+<html>
+<head></head>
+<body>
+<!-- build:test({.tmp,app}) target -->
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
This pull request makes alternate search paths accessible to custom blocks.

This is useful when desiring to maintain a coherent interface between custom block handlers and the standard ones. Basically, it enables something like this:

```html
<!-- build:custom(.tmp) someTarget -->
  ...
<!-- endbuild -->
```

In addition, this PR refactors the parsing of the build blocks to be a little more explicit about what we're getting, i.e.:

```js
sections[[build.type, build.target, build.attbs].join(sectionsJoinChar)] = last = [];
// vs
sections[[build[1], build[3].trim(), build[4].trim()].join(sectionsJoinChar)] = last = [];
```