### PR TITLE
Fix not being able to have multiple blocks with the same definition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,24 +69,32 @@ function getBlocks(body) {
   var lines = body.replace(/\r\n/g, '\n').split(/\n/),
     block = false,
     sections = {},
+    sectionIndex = 0,
     last,
     removeBlockIndex = 0;
 
   lines.forEach(function (l) {
     var build = parseBuildBlock(l),
-      endbuild = regend.test(l);
+      endbuild = regend.test(l),
+      sectionKey;
 
     if (build) {
       block = true;
 
       if(build.type === 'remove') { build.target = String(removeBlockIndex++); }
       if(build.attbs) {
-        sections[[build.type, build.target, build.attbs].join(sectionsJoinChar)] = last = [];
+        sectionKey = [build.type, build.target, build.attbs].join(sectionsJoinChar);
       } else if (build.target) {
-        sections[[build.type, build.target].join(sectionsJoinChar)] = last = [];
+        sectionKey = [build.type, build.target].join(sectionsJoinChar);
       } else {
-        sections[build.type] = last = [];
+        sectionKey = build.type;
       }
+
+      if (sections[sectionKey]) {
+        sectionKey += sectionIndex++;
+      }
+
+      sections[sectionKey] = last = [];
     }
 
     // switch back block flag when endbuild

--- a/test/test.js
+++ b/test/test.js
@@ -162,4 +162,13 @@ describe('html-ref-replace', function() {
       }
     });
   });
+
+  it('should handle multiple identical blocks separately', function () {
+    var result = useRef(fread(djoin('testfiles/25.html')), {
+      testSame: function (content, target) {
+        return target;
+      }
+    });
+    expect(result[0]).to.equal(fread(djoin('testfiles/25-expected.html')));
+  });
 });

--- a/test/testfiles/25-expected.html
+++ b/test/testfiles/25-expected.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+target
+
+target
+</body>
+</html>

--- a/test/testfiles/25.html
+++ b/test/testfiles/25.html
@@ -1,0 +1,10 @@
+<html>
+<head></head>
+<body>
+<!-- build:testSame target -->
+<!-- endbuild -->
+
+<!-- build:testSame target -->
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
Currently node-useref does not support having multiple blocks with the same definition - this seems like an arbitrary limitation.

This PR makes it parse multiple blocks with the same definition independently of one another by adding a unique identifier if necessary. 
